### PR TITLE
Relax the very specific python 3.11.1 dependency to 3.11

### DIFF
--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -15,7 +15,7 @@ include = [
     ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<=3.11.1"
+python = ">=3.8,<=3.11"
 nibabel = ">=3.2.1"
 numpy = "^1.21.3"
 pyparsing = "^3.0.4"


### PR DESCRIPTION
If I install pypet2bids in a fresh python 3.11 environment I get an error (see below) because pypet2bids depends on the obsolete python 3.11.1 version. I think it is safe to always use the latest 3.11 version, hence this PR

```console
py311: install_package_deps> python -I -m pip install 'pypet2bids>=1.0.12'
ERROR: Ignored the following versions that require a different python version: 0.0.10 Requires-Python >3.7.1,<3.10; 0.0.11 Requires-Python >3.7.1,<3.10; 0.0.12 Requires-Python >3.7.1,<3.10; 0.0.13 Requires-Python >3.7.1,<3.10; 0.0.14 Requires-Python >3.7.1,<3.10; 0.0.15 Requires-Python >3.7.1,<3.10; 0.0.4 Requires-Python >3.7.1,<3.10; 0.0.6 Requires-Python >3.7.1,<3.10; 0.0.7 Requires-Python >3.7.1,<3.10; 0.0.8 Requires-Python >3.7.1,<3.10; 0.0.9 Requires-Python >3.7.1,<3.10; 1.0.0 Requires-Python >3.7.1,<3.10; 1.0.10 Requires-Python >=3.8,<3.11; 1.0.12 Requires-Python >=3.8,<=3.11.1; 1.0.2 Requires-Python >3.7.1,<3.10; 1.0.5 Requires-Python >=3.8,<3.11; 1.0.7 Requires-Python >=3.8,<3.11; 1.0.8 Requires-Python >=3.8,<3.11; 1.0.9 Requires-Python >=3.8,<3.11; 1.1.0 Requires-Python >=3.8,<=3.11.1; 1.1.1 Requires-Python >=3.8,<=3.11.1; 1.1.2 Requires-Python >=3.8,<=3.11.1; 1.2.2 Requires-Python >=3.8,<=3.11.1; 1.2.3 Requires-Python >=3.8,<=3.11.1
ERROR: Could not find a version that satisfies the requirement pypet2bids>=1.0.12 (from versions: 1.0.4)
ERROR: No matching distribution found for pypet2bids>=1.0.12
```